### PR TITLE
Add barcode scanning screen

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -52,6 +52,7 @@ function RootLayoutNav() {
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="scan" options={{ title: 'Scan' }} />
         <Stack.Screen name="modal" options={{ presentation: 'modal' }} />
       </Stack>
     </ThemeProvider>

--- a/app/scan.tsx
+++ b/app/scan.tsx
@@ -1,10 +1,66 @@
 // app/scan.tsx
-import { View, Text } from 'react-native';
+import { useEffect, useState } from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+import { BarCodeScanner } from 'expo-barcode-scanner';
 
 export default function ScanScreen() {
+  const [hasPermission, setHasPermission] = useState<boolean | null>(null);
+  const [scanned, setScanned] = useState(false);
+  const [data, setData] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      const { status } = await BarCodeScanner.requestPermissionsAsync();
+      setHasPermission(status === 'granted');
+    })();
+  }, []);
+
+  const handleBarCodeScanned = ({ type, data }: { type: string; data: string }) => {
+    setScanned(true);
+    setData(data);
+  };
+
+  if (hasPermission === null) {
+    return (
+      <View style={styles.centered}>
+        <Text>Requesting camera permission...</Text>
+      </View>
+    );
+  }
+
+  if (hasPermission === false) {
+    return (
+      <View style={styles.centered}>
+        <Text>No access to camera</Text>
+      </View>
+    );
+  }
+
   return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Text>Scan screen placeholder</Text>
+    <View style={{ flex: 1 }}>
+      {scanned && (
+        <View style={styles.centered}>
+          <Text style={styles.scanText}>{data}</Text>
+          <Button title="Tap to Scan Again" onPress={() => setScanned(false)} />
+        </View>
+      )}
+      {!scanned && (
+        <BarCodeScanner
+          onBarCodeScanned={handleBarCodeScanned}
+          style={StyleSheet.absoluteFillObject}
+        />
+      )}
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  scanText: {
+    marginBottom: 20,
+  },
+});


### PR DESCRIPTION
## Summary
- implement Expo barcode scanning screen with permission handling
- wire up scan route in navigation
- ensure app config includes expo-barcode-scanner plugin

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68abbbc5f888832daedc5931cab0511d